### PR TITLE
Fix incorrect use of unstable intrinsic

### DIFF
--- a/src/guards/slice_memory_guard.rs
+++ b/src/guards/slice_memory_guard.rs
@@ -3,7 +3,7 @@ use core::{
     mem::{MaybeUninit, transmute},
     ptr::{drop_in_place, write},
 };
-use std::intrinsics::copy_nonoverlapping;
+use std::ptr::copy_nonoverlapping;
 
 /// Guard-struct used for correctly initialize uninitialized memory and `drop` it when guard goes out of scope.
 /// Usually, you *should not* use this struct to handle your memory.


### PR DESCRIPTION
rust-lang/rust#95956 changed the way unstable modules works and broke the use of `std::intrinsics::copy_nonoverlapping` in this crate. This PR changes it to use the stable re-export under `std::ptr`.

Fixes #10