### PR TITLE
Mark alloc_array function as unsafe

### DIFF
--- a/src/alloc_array.rs
+++ b/src/alloc_array.rs
@@ -8,7 +8,7 @@ use crate::try_inplace_array;
 /// It allocates a vector with `size` elements and fills it up with help of `init` closure
 /// and then pass a reference to a slice of the vector into the `consumer` closure.
 /// `consumer`'s result will be returned.
-pub fn alloc_array<T, R, Consumer: FnOnce(UninitializedSliceMemoryGuard<T>) -> R>(size: usize, consumer: Consumer) -> R {
+pub unsafe fn alloc_array<T, R, Consumer: FnOnce(UninitializedSliceMemoryGuard<T>) -> R>(size: usize, consumer: Consumer) -> R {
     unsafe {
         let mut memory_holder = Vec::<MaybeUninit<T>>::with_capacity(size);
         memory_holder.set_len(size);
@@ -58,7 +58,7 @@ pub fn inplace_or_alloc_array<T, R, Consumer>(size: usize, consumer: Consumer) -
 {
     match try_inplace_array(size, consumer) {
         Ok(result) => result,
-        Err(consumer) => alloc_array(size, consumer),
+        Err(consumer) => unsafe { alloc_array(size, consumer) },
     }
 }
 

--- a/tests/drop_correctness.rs
+++ b/tests/drop_correctness.rs
@@ -89,12 +89,12 @@ fn inplace_array_should_correctly_drop_values() {
 fn alloc_array_should_correctly_drop_values() {
     for i in (0..4096).step_by(8) {
         DropCounter::clear();
-        alloc_array(i, |_guard: UninitializedSliceMemoryGuard<DropCounterTrigger>| {});
+        unsafe { alloc_array(i, |_guard: UninitializedSliceMemoryGuard<DropCounterTrigger>| {}) };
         assert_eq!(DropCounter::get(), 0);
         DropCounter::clear();
-        alloc_array(i, |guard| {
+        unsafe { alloc_array(i, |guard| {
             guard.init(|_| DropCounterTrigger::new());
-        });
+        }) };
         assert_eq!(DropCounter::get(), i);
     }
 }


### PR DESCRIPTION
https://github.com/NotIntMan/inplace_it/blob/50eee1f9996bdf7aff51b1dc9059f6861b79043b/src/alloc_array.rs#L11-L19
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.